### PR TITLE
[UpData]　回避するとプレイヤーが浮くバグを解消。原因は、変更先のレイヤーがマップ範囲のLyaerと重なるようになってしまうためめり…

### DIFF
--- a/Assets/Game/Player/Script/01Component/PlayerController.cs
+++ b/Assets/Game/Player/Script/01Component/PlayerController.cs
@@ -27,6 +27,8 @@ namespace Player
         [Tooltip("プレイヤーのオブジェクト"), SerializeField]
         private GameObject _player;
 
+
+
         [Header("プレイヤーのアニメーター")]
         [Tooltip("プレイヤーのアニメーター"), SerializeField]
         private Animator _playerAnim;

--- a/Assets/Game/Player/Script/02Behavior/Avoidance.cs
+++ b/Assets/Game/Player/Script/02Behavior/Avoidance.cs
@@ -48,9 +48,9 @@ namespace Player
         private float _landDeceleration = 20f;
 
         [Header("回避した時のレイヤー")]
-        [SerializeField]   private string _avoidLayerName;
+        [SerializeField] private string _avoidLayerName;
         [Header("最初のレイヤー")]
-        [SerializeField]   private string _defultLayerName;
+        [SerializeField] private string _defultLayerName;
 
         [Tooltip("現在の速度 : インスペクタで値を追跡する用"), SerializeField]
         private float _currentHorizontalSpeed = 0f;
@@ -279,6 +279,8 @@ namespace Player
             _testAvoidText.SetActive(true);
 
             Debug.Log("その場回避始め！");
+
+
             _playerController.Player.layer = LayerMask.NameToLayer(_avoidLayerName);
             _playerController.LifeController.IsGodMode = true;
         }
@@ -292,8 +294,9 @@ namespace Player
 
             Debug.Log("その場回避終了！");
             _playerController.LifeController.IsGodMode = false;
+
             _playerController.Player.layer = LayerMask.NameToLayer(_defultLayerName);
-            //回避が終了したことをMoveクラスに伝える
+            ////回避が終了したことをMoveクラスに伝える
             _playerController.Move.EndOtherAction();
 
             _isAvoidacneNow = false;

--- a/ProjectSettings/Physics2DSettings.asset
+++ b/ProjectSettings/Physics2DSettings.asset
@@ -53,4 +53,4 @@ Physics2DSettings:
   m_ColliderAsleepColor: {r: 0.5686275, g: 0.95686275, b: 0.54509807, a: 0.36078432}
   m_ColliderContactColor: {r: 1, g: 0, b: 1, a: 0.6862745}
   m_ColliderAABBColor: {r: 1, g: 1, b: 0, a: 0.2509804}
-  m_LayerCollisionMatrix: ff33ffffff73ffffff73ffffff72ffffff73ffffff73ffffbf31fffffff7fffff773ffffbf33ffff8070ffff0070ffffff7fffffff3fffffbe5dffff8000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+  m_LayerCollisionMatrix: ff73ffffff73ffffff73ffffff72ffffff73ffffff73ffffbf31fffffff7fffff773ffffbf33ffff8030ffff0030ffffff7fffffff3fffffbf51ffff8000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff


### PR DESCRIPTION
…込んでいたから