### PR TITLE
[fix] TitleのSelectが外れないように修正しました。

### DIFF
--- a/Assets/Game/Scenes/Title.unity
+++ b/Assets/Game/Scenes/Title.unity
@@ -8875,6 +8875,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 55d13d846aec03a428343409cccfbf71, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _gamepadText: <color=#FFD800>(B BUTTON)</color> BACK
+  _keyboardText: <color=#FFD800>(C KEY)</color> BACK
 --- !u!114 &1583997067
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -10027,6 +10029,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 55d13d846aec03a428343409cccfbf71, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _gamepadText: <color=#FFD800>(A BUTTON)</color> DECIDE
+  _keyboardText: <color=#FFD800>(ENTER KEY)</color> DECIDE
 --- !u!114 &1885581222 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 7865071447997208186, guid: 63fdb600dd323ac40b95c35fcc92c71a, type: 3}

--- a/Assets/Game/Title/MenuPanelController.cs
+++ b/Assets/Game/Title/MenuPanelController.cs
@@ -60,6 +60,7 @@ public class MenuPanelController : MonoBehaviour
 
         _canvasAnimator.SetBool(_animationParameterName, false);
         EventSystem.current.SetSelectedGameObject(null);
+        GameManager.Instance.AudioManager.Save();
         _panelEnabled = false;
         _particleAnim.AnimPlay();
     }

--- a/Assets/Game/Title/TipsAnimation.cs
+++ b/Assets/Game/Title/TipsAnimation.cs
@@ -1,18 +1,46 @@
 using UnityEngine;
 using UnityEngine.UI;
+using UnityEngine.InputSystem;
 using DG.Tweening;
 
 public class TipsAnimation : MonoBehaviour
 {
+    [SerializeField]
+    private string _gamepadText = "";
+    [SerializeField]
+    private string _keyboardText = "";
     private Text _tipsText = default;
+    private string _currentText = "";
+    private InputAction _gamepad = new InputAction(binding: "<Gamepad>/*");
+    private InputAction _mouse = new InputAction(binding: "<Mouse>/*");
 
     private void Awake()
     {
         _tipsText = GetComponent<Text>();
+        _gamepad.Enable();
+        _mouse.Enable();
+    }
+
+    private void Update()
+    {
+        if (_gamepad.WasPressedThisFrame() &&
+            _currentText != _gamepadText
+        )
+        {
+            ChangeTips(_gamepadText);
+        }
+        else if (Keyboard.current.anyKey.wasPressedThisFrame ||
+            _mouse.WasPressedThisFrame() &&
+            _currentText != _keyboardText
+        )
+        {
+            ChangeTips(_keyboardText);
+        }
     }
 
     public void ChangeTips(string text)
     {
+        _currentText = text;
         _tipsText.DOText(text, 1.0f, scrambleMode: ScrambleMode.Uppercase).SetEase(Ease.Linear);
     }
 }

--- a/Assets/Game/Title/TitleController.cs
+++ b/Assets/Game/Title/TitleController.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.EventSystems;
 
 /// <summary>
 /// タイトル画面を制御するクラス
@@ -12,6 +13,7 @@ public class TitleController : MonoBehaviour
     private GameObject[] _firstNotNeededObject = default;
 
     private TitleState _currentState = TitleState.Title;
+    private GameObject _lastSelectedObject = default;
     public TitleState CurrentState
     {
         get { return _currentState; }
@@ -23,6 +25,18 @@ public class TitleController : MonoBehaviour
         GameManager.Instance.AudioManager.Load();
         GameManager.Instance.AudioManager.PlayBGM("CueSheet_Gun", "BGM_Title");
         Setup();
+    }
+
+    private void Update()
+    {
+        if (EventSystem.current.currentSelectedGameObject == null)
+        {
+            EventSystem.current.SetSelectedGameObject(_lastSelectedObject);
+        }  
+        else if (EventSystem.current.currentSelectedGameObject != _lastSelectedObject)
+        {
+            _lastSelectedObject = EventSystem.current.currentSelectedGameObject;
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
TitleのTipsの表記をGamepadとKeyboardMouseで変わるように変更しました
TitleのAudioPanelを閉じた際に、AudioManager.Save()を呼ぶように変更しました。